### PR TITLE
🎨 Changes of JWT 2.9.2

### DIFF
--- a/lib/omniauth/strategies/entra_id.rb
+++ b/lib/omniauth/strategies/entra_id.rb
@@ -154,16 +154,14 @@ module OmniAuth
 
           # https://learn.microsoft.com/en-us/entra/identity-platform/id-tokens#validate-tokens
           #
-          JWT::Verify.verify_claims(
-            id_token_data,
-            verify_iss:        !issuer.nil?,
-            iss:               issuer,
-            verify_aud:        true,
-            aud:               options.client_id,
-            verify_expiration: true,
-            verify_not_before: true,
-            leeway:            options[:jwt_leeway]
-          )
+          verify_params = {
+            aud: options.client_id,
+            exp: { leeway: options.jwt_leeway },
+            nbf: { leeway: options.jwt_leeway }
+          }
+          verify_params[:iss] = issuer unless issuer.nil?
+
+          ::JWT::Claims.verify_payload!(id_token_data, verify_params)
 
           auth_token_data = begin
             ::JWT.decode(access_token.token, nil, false).first

--- a/omniauth-entra-id.gemspec
+++ b/omniauth-entra-id.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/RIPAGlobal/omniauth-entra-id'
   }
 
+  s.add_runtime_dependency('jwt', '>= 2.9.2')
   s.add_runtime_dependency('omniauth-oauth2', '~> 1.8')
 
   s.add_development_dependency('debug', '~>  1.9 ')


### PR DESCRIPTION
Hi,

The JWT gem at version v2.9.2 mark some APIs as internal only and/or deprecated. And in the version 3.0.0 (released at 2025-06-14) the used `JWT::Verify` is no more usable.

Fix #44 

For context, see the discussion here:

- https://github.com/jwt/ruby-jwt/issues/623
- https://github.com/jwt/ruby-jwt/pull/626
- https://github.com/jwt/ruby-jwt/pull/654